### PR TITLE
fix: Testing Latest CodeBuild Images (NGTSK-147)

### DIFF
--- a/v1/iac/cfn/codebuild/build.yaml
+++ b/v1/iac/cfn/codebuild/build.yaml
@@ -60,11 +60,12 @@ Parameters:
     - "aws/codebuild/amazonlinux2-x86_64-standard:1.0"
     - "aws/codebuild/amazonlinux2-x86_64-standard:2.0"
     - "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
+    - "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
     - "aws/codebuild/standard:1.0"
     - "aws/codebuild/standard:2.0"
     - "aws/codebuild/standard:3.0"
     - "aws/codebuild/standard:4.0"
-    Default: "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
+    Default: "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
   CodeBuildTimeoutInMinutes:
     Type: "Number"
     Default: 10

--- a/v1/iac/cfn/codebuild/test.yaml
+++ b/v1/iac/cfn/codebuild/test.yaml
@@ -46,11 +46,12 @@ Parameters:
     - "aws/codebuild/amazonlinux2-x86_64-standard:1.0"
     - "aws/codebuild/amazonlinux2-x86_64-standard:2.0"
     - "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
+    - "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
     - "aws/codebuild/standard:1.0"
     - "aws/codebuild/standard:2.0"
     - "aws/codebuild/standard:3.0"
     - "aws/codebuild/standard:4.0"
-    Default: "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
+    Default: "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
   CodeBuildTimeoutInMinutes:
     Type: "Number"
     Default: 10

--- a/v1/package-lock.json
+++ b/v1/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boilerplate-fargate-appconfig",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/v1/package.json
+++ b/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boilerplate-fargate-appconfig",
-  "version": "1.0.13",
+  "version": "1.1.0",
   "description": "This is a Fargate/AppConfig application boilerplate.",
   "main": "src/app.js",
   "repository": {


### PR DESCRIPTION
The tests are failing because the 3.0 images have old versions of node, I think that the 4.0 versions will correct this.