### PR TITLE
refactor: Change how the HTTP/2 test works (NGTSK-147)

### DIFF
--- a/v1/package.json
+++ b/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boilerplate-fargate-appconfig",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "description": "This is a Fargate/AppConfig application boilerplate.",
   "main": "src/app.js",
   "type": "module",

--- a/v1/test/cucumber/infrastructure/network/steps/http2.js
+++ b/v1/test/cucumber/infrastructure/network/steps/http2.js
@@ -1,24 +1,88 @@
 import assert from "assert";
 import { Given, When, Then } from "@cucumber/cucumber";
-import checkHttp2 from "is-http2";
+import http2 from "node:http2";
 
 //Set global variables.
-var isHttp2 = false;
+let isHttp2 = false;
 
 When('we request the homepage via the {string} protocol', (value,done) => {
-  let domain = process.env.SERVICE_DOMAIN;
 
-  checkHttp2(domain, { includeSpdy : false } )
-    .then(function(result) {
-      isHttp2=result.isHttp2;
-      done();
-    })
-    .catch(function(error) {
-      console.error(error);
+  function testHttp2() {
+
+    let domain = process.env.SERVICE_DOMAIN;
+
+    const client = http2.connect(`https://${domain}:443`);
+
+    client.setTimeout(5000); //Set the timer for five seconds.
+
+    function returnClientError(error) {
+  
+      console.error(error.code);
+  
+      if (error.code == "ERR_HTTP2_ERROR") {
+  
+        console.info("HTTP/2 is not enabled.");
+  
+      } else {
+  
+        console.error("Some other connection error.");
+  
+      }
+  
+      isHttp2 = false;
+  
+      client.close();
+
       done(error);
-    });
+  
+    }
+  
+    function returnClientConnect() {
+  
+      console.info("Connection is ready...");
+  
+      /* Set the flag to true, because a connection was made,
+         we might still get an HTTP/2 error, but that will come later */
+      isHttp2 = true;
+  
+    }
+  
+    function returnClientTimeout() {
+  
+      console.warn("Timeout reached wihtout error...");
+  
+      client.close();
+
+      done();
+  
+    }
+  
+    client.on("error", returnClientError);
+  
+    client.on("timeout", returnClientTimeout);
+  
+    client.on("connect",returnClientConnect);
+
+  }
+
+  try {
+
+    testHttp2();
+  
+  } catch(error) {
+  
+    isHttp2 = false;
+  
+    console.error(error.code);
+
+    done(error);
+
+  }
+
 });
 
 Then('we should receive a response via the {string} protocol', (value) => {
+
   assert.strictEqual(isHttp2,true);
+
 });


### PR DESCRIPTION
The old module appears to have been abandoned and there are more modern ways to do this test.