### PR TITLE
fix: Updating HTTP/2 test (NGTSK-147)

### DIFF
--- a/v1/package.json
+++ b/v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boilerplate-fargate-appconfig",
-  "version": "1.6.13",
+  "version": "1.6.14",
   "description": "This is a Fargate/AppConfig application boilerplate.",
   "main": "src/app.js",
   "type": "module",

--- a/v1/test/cucumber/infrastructure/network/steps/http2.js
+++ b/v1/test/cucumber/infrastructure/network/steps/http2.js
@@ -13,7 +13,7 @@ When('we request the homepage via the {string} protocol', (value,done) => {
 
     const client = http2.connect(`https://${domain}:443`);
 
-    client.setTimeout(5000); //Set the timer for five seconds.
+    client.setTimeout(10000); //Set the timer for five seconds.
 
     function returnClientError(error) {
   
@@ -40,10 +40,20 @@ When('we request the homepage via the {string} protocol', (value,done) => {
     function returnClientConnect() {
   
       console.info("Connection is ready...");
-  
+
       /* Set the flag to true, because a connection was made,
          we might still get an HTTP/2 error, but that will come later */
       isHttp2 = true;
+  
+      function waitHttp2Check() {
+  
+        console.info("Closing the connection...");
+        client.close();
+        done();
+  
+      }
+  
+      setTimeout(waitHttp2Check, 3000);
   
     }
   


### PR DESCRIPTION
Once the connection is established, we need to wait a bit while the HTTP/2 connection test happens.

If we don't get an error shortly after the successful connection, then we know that HTTP/2 is working.

NOTE: There might be a cleaner way to do this, but the callback options appear to be limited for this specific test.